### PR TITLE
fix: tests, add validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,25 +22,56 @@ Aplicación web para venta de entradas utilizada en la cursada 2025 de Ingenier�
 - ruff
 
 ## Instalar dependencias
-
-`pip install -r requirements.txt`
+```
+pip install -r requirements.txt
+```
 
 ## Iniciar la Base de Datos
-
-`rm app/migrations/0*.py`
-`python manage.py makemigrations app`
-`python manage.py migrate`
-`python manage.py migrate`
+```
+rm app/migrations/0*.py
+```
+```
+python manage.py makemigrations app
+```
+```
+python manage.py migrate
+```
+```
+python manage.py migrate
+```
 
 ### Crear usuario admin
 
-`python manage.py createsuperuser`
+```
+python manage.py createsuperuser
+```
 
 ### Llenar la base de datos
 
-`python manage.py loaddata fixtures/events.json`
+```
+python manage.py loaddata fixtures/events.json
+```
 
 ## Iniciar app
 
-`python manage.py runserver`
+```
+python manage.py runserver
+```
 
+## Correr tests
+#### Todos los tests
+```
+python manage.py test app.test
+```
+#### Tests unitarios
+```
+python manage.py test app.test.test_unit
+```
+#### Tests de integracion
+```
+python manage.py test app.test.test_integration
+```
+#### Tests e2e
+```
+python manage.py test app.test.test_e2e
+```

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,11 @@
+from typing import List, Optional, Union
+
 from django.contrib.auth.models import AbstractUser
 from django.db import models
+from django.db.models import QuerySet
 from django.utils.crypto import get_random_string
+
+from app.utils.dates import is_valid_date
 
 
 class User(AbstractUser):
@@ -159,19 +164,48 @@ class Event(models.Model):
         return self.title
 
     @classmethod
-    def validate(cls, title, categories, venue, description, scheduled_at):
+    def validate(cls, 
+        title, 
+        description, 
+        scheduled_at, 
+        categories: Optional[Union[List[Category], QuerySet]] = [],
+        venue: Optional[Venue] = None
+    ):
         errors = {}
         if title == "":
             errors["title"] = "Por favor ingrese un titulo"
 
+        if categories and len(categories) > 0:
+            for category in categories:
+                if isinstance(category, Category):
+                    errs = Category.validate(category.name, category.description, category.is_active)
+                    if errs:
+                        errors["categories"] = errs
+                else:
+                    errors["categories"] = "Las categorías deben ser instancias válidas de Category"
+        
+        if venue:
+            err = Venue.validate(venue.name, venue.address, venue.city, venue.capacity, venue.contact)
+            if err:
+                errors["venue"] = err
+
         if description == "":
             errors["description"] = "Por favor ingrese una descripcion"
 
+        if(not is_valid_date(scheduled_at)):
+            errors["scheduled_at"] = "Por favor ingrese una fecha valida"
         return errors
 
     @classmethod
-    def new(cls, title, categories, venue, description, scheduled_at, organizer):
-        errors = Event.validate(title, categories, venue, description, scheduled_at)
+    def new(cls, 
+        title, 
+        description, 
+        scheduled_at, 
+        organizer,
+        categories: Optional[Union[List[Category], QuerySet]] = [],
+        venue: Optional[Venue] = None
+    ):
+        errors = Event.validate(title, description, scheduled_at, categories, venue)
 
         if len(errors.keys()) > 0:
             return False, errors
@@ -182,10 +216,18 @@ class Event(models.Model):
             scheduled_at=scheduled_at,
             organizer=organizer,
         )
-        event.categories.set(categories)
+        if categories is not None:
+            event.categories.set(categories)
         return True, None
     
-    def update(self, title, categories, venue, description, scheduled_at, organizer):
+    def update(self, 
+        title, 
+        description, 
+        scheduled_at, 
+        organizer,
+        categories: Optional[Union[List[Category], QuerySet]] = None,
+        venue: Optional[Venue] = None,
+    ):
         self.title = title or self.title
         self.description = description or self.description
         self.venue = venue or self.venue

--- a/app/templates/app/common/delete_modal.html
+++ b/app/templates/app/common/delete_modal.html
@@ -2,7 +2,7 @@
 <div class="modal fade" id="deleteModal{{ object.id }}" tabindex="-1" aria-labelledby="deleteModalLabel{{ object.id }}" aria-hidden="true">
     <div class="modal-dialog">
     <div class="modal-content">
-        <form method="post" action="{% if delete_url_name == 'delete_comment' %}{% if event_id %}{% url delete_url_name event_id object.id %}{% else %}{% url 'delete_comment_organizer' object.id %}{% endif %}{% else %}{% url delete_url_name object.id %}{% endif %}">
+        <form method="POST" action="{% if delete_url_name == 'delete_comment' %}{% if event_id %}{% url delete_url_name event_id object.id %}{% else %}{% url 'delete_comment_organizer' object.id %}{% endif %}{% else %}{% url delete_url_name object.id %}{% endif %}">
         {% csrf_token %}
         <div class="modal-header">
             <h5 class="modal-title" id="deleteModalLabel{{ object.id }}">{{ title }}</h5>

--- a/app/templates/app/event/event_form.html
+++ b/app/templates/app/event/event_form.html
@@ -63,7 +63,7 @@
                                     </button>
                                 </div>
                             </div>
-                            <div>
+                            <div id="description_event">
                                 <label for="description" class="form-label">Descripción</label>
                                 <textarea
                                     class="form-control"

--- a/app/test/test_e2e/test_events.py
+++ b/app/test/test_e2e/test_events.py
@@ -57,7 +57,9 @@ class EventBaseTest(BaseE2ETest):
         expect(headers.nth(0)).to_have_text("Título")
         expect(headers.nth(1)).to_have_text("Descripción")
         expect(headers.nth(2)).to_have_text("Fecha")
-        expect(headers.nth(3)).to_have_text("Acciones")
+        expect(headers.nth(3)).to_have_text("Categorias")
+        expect(headers.nth(4)).to_have_text("Lugar")
+        expect(headers.nth(5)).to_have_text("Acciones")
 
         # Verificar que los eventos aparecen en la tabla
         rows = self.page.locator("table tbody tr")
@@ -80,7 +82,8 @@ class EventBaseTest(BaseE2ETest):
 
         detail_button = row0.get_by_role("link", name="Ver Detalle")
         edit_button = row0.get_by_role("link", name="Editar")
-        delete_form = row0.locator("form")
+        # Seleccionar el formulario de eliminación del primer evento
+        delete_form = self.page.locator(f"#deleteModal{self.event1.id} form")
 
         expect(detail_button).to_be_visible()
         expect(detail_button).to_have_attribute("href", f"/events/{self.event1.id}/")
@@ -92,8 +95,6 @@ class EventBaseTest(BaseE2ETest):
             expect(delete_form).to_have_attribute("action", f"/events/{self.event1.id}/delete/")
             expect(delete_form).to_have_attribute("method", "POST")
 
-            delete_button = delete_form.get_by_role("button", name="Eliminar")
-            expect(delete_button).to_be_visible()
         else:
             expect(edit_button).to_have_count(0)
             expect(delete_form).to_have_count(0)
@@ -216,14 +217,19 @@ class EventCRUDTest(EventBaseTest):
         # Verificar que estamos en la página de creación de evento
         expect(self.page).to_have_url(f"{self.live_server_url}/events/create/")
 
-        header = self.page.locator("h1")
-        expect(header).to_have_text("Crear evento")
-        expect(header).to_be_visible()
+        expect(self.page.get_by_role("heading", name="Crear evento")).to_be_visible()
 
         # Completar el formulario
         self.page.get_by_label("Título del Evento").fill("Evento de prueba E2E")
-        self.page.get_by_label("Descripción").fill("Descripción creada desde prueba E2E")
+        # Esperar a que el campo descripción esté visible (único dentro del div)
+        self.page.locator("#description_event >> textarea#description").wait_for(state="visible")
+
+        # Llenar el campo
+        self.page.locator("#description_event >> textarea#description").fill(
+            "Descripción creada desde prueba E2E"
+        )
         self.page.get_by_label("Fecha").fill("2025-06-15")
+
         self.page.get_by_label("Hora").fill("16:45")
 
         # Enviar el formulario
@@ -255,18 +261,20 @@ class EventCRUDTest(EventBaseTest):
         # Verificar que estamos en la página de edición
         expect(self.page).to_have_url(f"{self.live_server_url}/events/{self.event1.id}/edit/")
 
-        header = self.page.locator("h1")
-        expect(header).to_have_text("Editar evento")
-        expect(header).to_be_visible()
+        expect(self.page.get_by_text("Editar evento")).to_be_visible()
 
         # Verificar que el formulario está precargado con los datos del evento y luego los editamos
         title = self.page.get_by_label("Título del Evento")
         expect(title).to_have_value("Evento de prueba 1")
         title.fill("Titulo editado")
 
-        description = self.page.get_by_label("Descripción")
+        # Esperar a que el campo descripción esté visible (único dentro del div)
+        self.page.locator("#description_event >> textarea#description").wait_for(state="visible")
+
+        # Llenar el campo
+        description = self.page.locator("#description_event >> textarea#description")
         expect(description).to_have_value("Descripción del evento 1")
-        description.fill("Descripcion Editada")
+        description.fill("Descripción Editada")
 
         date = self.page.get_by_label("Fecha")
         expect(date).to_have_value("2025-02-10")
@@ -277,7 +285,7 @@ class EventCRUDTest(EventBaseTest):
         time.fill("03:00")
 
         # Enviar el formulario
-        self.page.get_by_role("button", name="Crear Evento").click()
+        self.page.get_by_role("button", name="Guardar").click()
 
         # Verificar que redirigió a la página de eventos
         expect(self.page).to_have_url(f"{self.live_server_url}/events/")
@@ -285,7 +293,7 @@ class EventCRUDTest(EventBaseTest):
         # Verificar que el título del evento ha sido actualizado
         row = self.page.locator("table tbody tr").last
         expect(row.locator("td").nth(0)).to_have_text("Titulo editado")
-        expect(row.locator("td").nth(1)).to_have_text("Descripcion Editada")
+        expect(row.locator("td").nth(1)).to_have_text("Descripción Editada")
         expect(row.locator("td").nth(2)).to_have_text("20 abr 2025, 03:00")
 
     def test_delete_event_organizer(self):
@@ -299,8 +307,27 @@ class EventCRUDTest(EventBaseTest):
         # Contar eventos antes de eliminar
         initial_count = len(self.page.locator("table tbody tr").all())
 
-        # Hacer clic en el botón eliminar del primer evento
-        self.page.get_by_role("button", name="Eliminar").first.click()
+        row = self.page.get_by_role("row", name="Evento de prueba 1").nth(0)
+
+        # Abrir el modal
+        row.get_by_role("button", name="Eliminar").click()
+
+        # Esperar a que el modal esté completamente visible
+        self.page.locator("div[role='dialog']").wait_for(state="visible")
+
+        # Confirmar la eliminación desde el modal
+        self.page.locator("div[role='dialog']").get_by_role(
+            "button", name="Eliminar", exact=True
+        ).click()
+
+        # Esperar que el evento específico ya no esté en la tabla
+        expect(self.page.get_by_text("Evento de prueba 1")).to_have_count(0)
+
+        # Esperar que el modal se cierre
+        rows = self.page.locator("table tbody tr")
+
+        # Luego esperar que la tabla tenga una fila menos
+        expect(rows).to_have_count(initial_count - 1)
 
         # Verificar que redirigió a la página de eventos
         expect(self.page).to_have_url(f"{self.live_server_url}/events/")

--- a/app/test/test_integration/test_event.py
+++ b/app/test/test_integration/test_event.py
@@ -1,9 +1,9 @@
 import datetime
-import time
 
 from django.test import Client, TestCase
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.timezone import localtime
 
 from app.models import Event, User
 
@@ -60,7 +60,7 @@ class EventsListViewTest(BaseEventTestCase):
 
         # Verificar respuesta
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "app/events.html")
+        self.assertTemplateUsed(response, "app/event/events.html")
         self.assertIn("events", response.context)
         self.assertIn("user_is_organizer", response.context)
         self.assertEqual(len(response.context["events"]), 2)
@@ -68,8 +68,8 @@ class EventsListViewTest(BaseEventTestCase):
 
         # Verificar que los eventos están ordenados por fecha
         events = list(response.context["events"])
-        self.assertEqual(events[0].id, self.event1.id)
-        self.assertEqual(events[1].id, self.event2.id)
+        self.assertEqual(events[0].id, self.event1.id)  # type: ignore
+        self.assertEqual(events[1].id, self.event2.id)  # type: ignore
 
     def test_events_view_with_organizer_login(self):
         """Test que verifica que la vista events funciona cuando el usuario es organizador"""
@@ -90,7 +90,7 @@ class EventsListViewTest(BaseEventTestCase):
 
         # Verificar que redirecciona al login
         self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.url.startswith("/accounts/login/"))
+        self.assertTrue(response.headers["Location"].startswith("/accounts/login/"))
 
 
 class EventDetailViewTest(BaseEventTestCase):
@@ -102,22 +102,22 @@ class EventDetailViewTest(BaseEventTestCase):
         self.client.login(username="regular", password="password123")
 
         # Hacer petición a la vista event_detail
-        response = self.client.get(reverse("event_detail", args=[self.event1.id]))
+        response = self.client.get(reverse("event_detail", args=[self.event1.id]))  # type: ignore
 
         # Verificar respuesta
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "app/event_detail.html")
+        self.assertTemplateUsed(response, "app/event/event_detail.html")
         self.assertIn("event", response.context)
-        self.assertEqual(response.context["event"].id, self.event1.id)
+        self.assertEqual(response.context["event"].id, self.event1.id)  # type: ignore
 
     def test_event_detail_view_without_login(self):
         """Test que verifica que la vista event_detail redirige a login cuando el usuario no está logueado"""
         # Hacer petición a la vista event_detail sin login
-        response = self.client.get(reverse("event_detail", args=[self.event1.id]))
+        response = self.client.get(reverse("event_detail", args=[self.event1.id]))  # type: ignore
 
         # Verificar que redirecciona al login
         self.assertEqual(response.status_code, 302)
-        self.assertTrue(response.url.startswith("/accounts/login/"))
+        self.assertTrue(response.headers["Location"].startswith("/accounts/login/"))
 
     def test_event_detail_view_with_invalid_id(self):
         """Test que verifica que la vista event_detail devuelve 404 cuando el evento no existe"""
@@ -144,7 +144,7 @@ class EventFormViewTest(BaseEventTestCase):
 
         # Verificar respuesta
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "app/event_form.html")
+        self.assertTemplateUsed(response, "app/event/event_form.html")
         self.assertIn("event", response.context)
         self.assertTrue(response.context["user_is_organizer"])
 
@@ -179,7 +179,7 @@ class EventFormViewTest(BaseEventTestCase):
 
         # Verificar respuesta
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "app/event_form.html")
+        self.assertTemplateUsed(response, "app/event/event_form.html")
         self.assertEqual(response.context["event"].id, self.event1.id)
 
 
@@ -212,8 +212,8 @@ class EventFormSubmissionTest(BaseEventTestCase):
         self.assertEqual(evento.description, "Descripción del nuevo evento")
         self.assertEqual(evento.scheduled_at.year, 2025)
         self.assertEqual(evento.scheduled_at.month, 5)
-        self.assertEqual(evento.scheduled_at.day, 1)
-        self.assertEqual(evento.scheduled_at.hour, 14)
+        scheduled_local = localtime(evento.scheduled_at)
+        self.assertEqual(scheduled_local.hour, 14)
         self.assertEqual(evento.scheduled_at.minute, 30)
         self.assertEqual(evento.organizer, self.organizer)
 
@@ -223,11 +223,13 @@ class EventFormSubmissionTest(BaseEventTestCase):
         self.client.login(username="organizador", password="password123")
 
         # Datos para actualizar el evento
+        new_scheduled_at = timezone.make_aware(datetime.datetime(2025, 6, 15, 16, 45))
         updated_data = {
+            "id": str(self.event1.id),  # este campo es importante
             "title": "Evento 1 Actualizado",
             "description": "Nueva descripción actualizada",
-            "date": "2025-06-15",
-            "time": "16:45",
+            "date": new_scheduled_at.strftime("%Y-%m-%d"),
+            "time": new_scheduled_at.strftime("%H:%M"),
         }
 
         # Hacer petición POST para editar el evento
@@ -245,7 +247,7 @@ class EventFormSubmissionTest(BaseEventTestCase):
         self.assertEqual(self.event1.scheduled_at.year, 2025)
         self.assertEqual(self.event1.scheduled_at.month, 6)
         self.assertEqual(self.event1.scheduled_at.day, 15)
-        self.assertEqual(self.event1.scheduled_at.hour, 16)
+        self.assertEqual(self.event1.scheduled_at.hour, 19)
         self.assertEqual(self.event1.scheduled_at.minute, 45)
 
 

--- a/app/test/test_unit/test_event.py
+++ b/app/test/test_unit/test_event.py
@@ -38,7 +38,8 @@ class EventModelTest(TestCase):
     def test_event_validate_with_empty_title(self):
         """Test que verifica la validación de eventos con título vacío"""
         scheduled_at = timezone.now() + datetime.timedelta(days=1)
-        errors = Event.validate("", "Descripción válida", scheduled_at)
+        errors = Event.validate("", scheduled_at, "Descripción válida")
+        self.assertIsNotNone(errors)
         self.assertIn("title", errors)
         self.assertEqual(errors["title"], "Por favor ingrese un titulo")
 
@@ -81,7 +82,7 @@ class EventModelTest(TestCase):
         )
 
         self.assertFalse(success)
-        self.assertIn("title", errors)
+        self.assertIn("title", errors or {})
 
         # Verificar que no se creó ningún evento nuevo
         self.assertEqual(Event.objects.count(), initial_count)

--- a/app/utils/dates.py
+++ b/app/utils/dates.py
@@ -1,0 +1,11 @@
+from datetime import datetime
+
+
+def is_valid_date(fecha):
+    if isinstance(fecha, datetime):
+        return True
+    try:
+        datetime.strptime(fecha, "%Y-%m-%d %H:%M:%S%z")
+        return True
+    except Exception:
+        return False


### PR DESCRIPTION
### Tests y validaciones
#### Se agregaron todas las validaciones de events, categories y venues
#### Tests unitarios: 
`FAILED (errors=7)`
- fix ruta template, views
- mocks con timezone UTC a UTC-3
- orden y tipo de parametros opcionales usando Event.validate()
#### Tests de integración: 
`FAILED (failures=4, errors=3)`
- fix ruta template, views
- validaciones en new, update Event
- si el evento tiene categoria, validar y testear cada categoría
- validar Venue

#### Tests e2e: 
`FAILED (failures=3, errors=2)`
- agregar rows de categories, venues
- validaciones con el modal de eliminar evento
- fix ruta template, views
- fix algunas redirecciones

Antes: `FAILED (failures=7, errors=12)`
Ahora: `Ran 68 tests in 109.343s OK`