### PR TITLE
style: darkmode and footer

### DIFF
--- a/app/static/app/css/styles.css
+++ b/app/static/app/css/styles.css
@@ -1,3 +1,18 @@
+[data-bs-theme="dark"] .bg-light {
+    background-color: #262626 !important;
+  }
+
+[data-bs-theme="dark"] .table-light {
+    background-color: #262626 !important;
+    --bs-table-bg: #262626;
+    --bs-table-bg: #212529;
+    --bs-table-border-color: #c6c7c838;
+}
+
+[data-bs-theme="dark"] .table-light th {
+    color: #dee2e6 !important;
+}
+
 .star-rating {
     direction: rtl;
     font-size: 1.8rem;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -20,15 +20,32 @@
         name="viewport"
         content="width=device-width, initial-scale=1"
     />
-
+    <style>
+        [data-bs-theme="dark"] .bg-light {
+          background-color: #262626 !important;
+        }
+        [data-bs-theme="dark"] .table-light {
+            background-color: #262626 !important;
+            --bs-table-bg: #262626;
+            --bs-table-bg: #212529;
+            --bs-table-border-color: #c6c7c838;
+        }
+        [data-bs-theme="dark"] .table-light th {
+            color: #dee2e6 !important;
+        }
+      </style>
 </head>
 
 <body>
     <!-- Navbar solo visible si el usuario está autenticado -->
-    <nav class="navbar navbar-expand-md bg-body-tertiary mb-4">
+    <nav class="navbar navbar-expand-md bg-body-tertiary mb-4 px-2">
         <div class="container-fluid">
-            <a class="navbar-brand" href="/">EventHub</a>
-
+            <div>
+                <a class="navbar-brand" href="/">EventHub</a>
+                <button id="themeToggle" class="btn btn-outline-secondary">
+                    <i class="bi bi-moon-fill fs-5" id="themeIcon"></i>
+                </button>
+            </div>
             <div class="hstack gap-2">
                 {% if user.is_authenticated %}
                     <button
@@ -112,14 +129,49 @@
             </div>
         </div>
     </nav>
+     <main class="flex-grow-1 container">
+        {% block content %}
+        {% endblock %}
+    </main>
 
-    {% block content %}
-    {% endblock %}
+    <footer class="d-flex container flex-wrap justify-content-between align-items-center py-4 mt-5 border-top">
+        <div class="col-md-4 d-flex align-items-center">
+            <a href="/" class="mb-3 me-2 mb-md-0 text-body-secondary text-decoration-none lh-1" aria-label="Bootstrap">
+                <svg class="bi" width="30" height="24" aria-hidden="true"><use xlink:href="#bootstrap"></use></svg>
+            </a>
+            <span class="mb-3 mb-md-0 text-body-secondary">UTN FRLP - Ingeniería y calidad de software - Grupo 18</span>
+        </div>
+        <ul class="nav col-md-4 justify-content-end list-unstyled d-flex">
+            <li class="ms-3">
+                <a class="text-body-secondary d-flex align-items-center" href="https://github.com/xStranged1/eventhub" aria-label="Github" target="_blank">
+                    <i class="bi bi-github fs-4 me-2"></i>
+                    Github
+                </a>
+            </li>
+        </ul>
+    </footer>
 </body>
 <script
     src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-k6d4wzSIapyDyv1kpU366/PK5hCdSbCRGRCMv+eplOQJWyd1fbcAu9OCUj5zNLiq"
     crossorigin="anonymous"
 ></script>
+<script>
+    const toggle = document.getElementById("themeToggle");
+    const icon = document.getElementById("themeIcon");
+    const html = document.documentElement;
 
+    // Aplica el tema previamente guardado
+    const savedTheme = localStorage.getItem("theme") || "light";
+    html.setAttribute("data-bs-theme", savedTheme);
+    icon.className = savedTheme === "dark" ? "bi bi-sun-fill" : "bi bi-moon-fill";
+
+    toggle.addEventListener("click", () => {
+        const currentTheme = html.getAttribute("data-bs-theme");
+        const newTheme = currentTheme === "dark" ? "light" : "dark";
+        html.setAttribute("data-bs-theme", newTheme);
+        localStorage.setItem("theme", newTheme);
+        icon.className = newTheme === "dark" ? "bi bi-sun-fill" : "bi bi-moon-fill";
+    });
+</script>
 </html>


### PR DESCRIPTION
## Modo oscuro y footer
### Agregado:
- Toggle en el nav para cambiar modo claro-oscuro
- Guardar y recuperar la preferencia del modo del usuario en el localStorage
- Estilos de bg secundario, tablas, color del texto para modo oscuro
- Footer con numero de grupo y link al repositorio de Github